### PR TITLE
...

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,24 +1,12 @@
-This is free and unencumbered software released into the public domain.
+Copyright (C) 2026 by Brian M. Workman bmw@gesslar.dev
 
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <https://unlicense.org>
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the project's license from the **Unlicense** (public domain dedication) to the **ISC License** (copyright retained by Brian M. Workman).

- The Unlicense previously placed the software unconditionally into the public domain with no copyright reserved.
- The new ISC License is still permissive but retains copyright — users are permitted to use, copy, modify, and distribute the software, but copyright ownership remains with the author.
- The copyright year is listed as 2026, consistent with the current year.
- No source code files were changed — this is a license-only update.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a straightforward, intentional license change with no code modifications.

Only LICENSE.txt is modified. The change is clearly intentional (switching from Unlicense to ISC), there are no technical bugs, no code logic is affected, and the new license text is a standard, well-known permissive license.

No files require special attention beyond the intentional license change in LICENSE.txt.

<sub>Reviews (1): Last reviewed commit: ["..."](https://github.com/gesslar/gstick/commit/a542f59b839c2b411b5c0f2240e07062efbee84a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28043883)</sub>

<!-- /greptile_comment -->